### PR TITLE
PR (base:master) <- (compare:assignment/{sypark9646})

### DIFF
--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Animal.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Animal.java
@@ -1,0 +1,5 @@
+package com.example.sypark9646.item10;
+
+public interface Animal {
+		public abstract void jump();
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Cat.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Cat.java
@@ -1,0 +1,36 @@
+package com.example.sypark9646.item10;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Cat implements Animal {
+
+		private final String color;
+
+		public String getColor() {
+				return color;
+		}
+
+		@Override
+		public void jump() {
+				System.out.println("cat is jumping");
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Cat)) {
+						return false;
+				}
+
+				Cat cat = (Cat) o;
+				return this.color.equals(cat.color);
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Circle.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Circle.java
@@ -1,0 +1,39 @@
+package com.example.sypark9646.item10;
+
+public class Circle {
+
+		Shape shape;
+		int radius;
+
+		public Circle() {
+				System.out.println("Circle 호출");
+		}
+
+		public Circle(int x, int y, int radius) {
+				this.shape = new Shape(x, y);
+				this.radius = radius;
+		}
+
+		public void drawCenter() {
+				shape.drawCenter();
+				System.out.println("radius = " + radius);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Circle)) {
+						return false;
+				}
+
+				Circle circle = (Circle) o;
+				return this.shape.equals(circle.shape) && this.radius == circle.radius;
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Dog.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Dog.java
@@ -1,0 +1,36 @@
+package com.example.sypark9646.item10;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Dog implements Animal {
+
+		private final String color;
+
+		public String getColor() {
+				return color;
+		}
+
+		@Override
+		public void jump() {
+				System.out.println("dog is jumping");
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Dog)) {
+						return false;
+				}
+
+				Dog dog = (Dog) o;
+				return this.color.equals(dog.color);
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Rectangle.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Rectangle.java
@@ -1,0 +1,40 @@
+package com.example.sypark9646.item10;
+
+public class Rectangle {
+
+		Shape shape;
+		int row, col;
+
+		public Rectangle() {
+				System.out.println("Rectangle 호출");
+		}
+
+		public Rectangle(int x, int y, int row, int col) {
+				this.shape = new Shape(x, y);
+				this.row = row;
+				this.col = col;
+		}
+
+		public void drawCenter() {
+				shape.drawCenter();
+				System.out.println("row = " + row + ", col = " + col);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Rectangle)) {
+						return false;
+				}
+
+				Rectangle rectangle = (Rectangle) o;
+				return this.shape.equals(rectangle.shape) && this.row == rectangle.row && this.col == rectangle.col;
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item10/Shape.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item10/Shape.java
@@ -1,0 +1,37 @@
+package com.example.sypark9646.item10;
+
+public class Shape {
+
+		protected int x, y;
+
+		public Shape() {
+				System.out.println("Shape 호출");
+		}
+
+		public Shape(int x, int y) {
+				this.x = x;
+				this.y = y;
+		}
+
+		public void drawCenter() {
+				System.out.println("x = " + x + ", y = " + y);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Shape)) {
+						return false;
+				}
+
+				Shape shape = (Shape) o;
+				return this.x == shape.x && this.y == shape.y;
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Animal.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Animal.java
@@ -1,0 +1,5 @@
+package com.example.sypark9646.item11;
+
+public interface Animal {
+		public abstract void jump();
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Cat.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Cat.java
@@ -1,0 +1,41 @@
+package com.example.sypark9646.item11;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Cat implements Animal {
+
+		private final String color;
+
+		public String getColor() {
+				return color;
+		}
+
+		@Override
+		public void jump() {
+				System.out.println("cat is jumping");
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Cat)) {
+						return false;
+				}
+
+				Cat cat = (Cat) o;
+				return this.color.equals(cat.color);
+		}
+
+		@Override
+		public int hashCode() {
+				return color.hashCode();
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Circle.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Circle.java
@@ -1,0 +1,46 @@
+package com.example.sypark9646.item11;
+
+public class Circle {
+
+		Shape shape;
+		int radius;
+
+		public Circle() {
+				System.out.println("Circle 호출");
+		}
+
+		public Circle(int x, int y, int radius) {
+				this.shape = new Shape(x, y);
+				this.radius = radius;
+		}
+
+		public void drawCenter() {
+				shape.drawCenter();
+				System.out.println("radius = " + radius);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Circle)) {
+						return false;
+				}
+
+				Circle circle = (Circle) o;
+				return this.shape.equals(circle.shape) && this.radius == circle.radius;
+		}
+
+		@Override
+		public int hashCode() {
+				int result = shape.hashCode();
+				result = 31 * result + Integer.hashCode(radius);
+				return result;
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Dog.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Dog.java
@@ -1,0 +1,41 @@
+package com.example.sypark9646.item11;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Dog implements Animal {
+
+		private final String color;
+
+		public String getColor() {
+				return color;
+		}
+
+		@Override
+		public void jump() {
+				System.out.println("dog is jumping");
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Dog)) {
+						return false;
+				}
+
+				Dog dog = (Dog) o;
+				return this.color.equals(dog.color);
+		}
+
+		@Override
+		public int hashCode() {
+				return color.hashCode();
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Rectangle.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Rectangle.java
@@ -1,0 +1,48 @@
+package com.example.sypark9646.item11;
+
+public class Rectangle {
+
+		Shape shape;
+		int row, col;
+
+		public Rectangle() {
+				System.out.println("Rectangle 호출");
+		}
+
+		public Rectangle(int x, int y, int row, int col) {
+				this.shape = new Shape(x, y);
+				this.row = row;
+				this.col = col;
+		}
+
+		public void drawCenter() {
+				shape.drawCenter();
+				System.out.println("row = " + row + ", col = " + col);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Rectangle)) {
+						return false;
+				}
+
+				Rectangle rectangle = (Rectangle) o;
+				return this.shape.equals(rectangle.shape) && this.row == rectangle.row && this.col == rectangle.col;
+		}
+
+		@Override
+		public int hashCode() {
+				int result = shape.hashCode();
+				result = 31 * result + Integer.hashCode(row);
+				result = 31 * result + Integer.hashCode(col);
+				return result;
+		}
+}

--- a/sypark9646/src/main/java/com/example/sypark9646/item11/Shape.java
+++ b/sypark9646/src/main/java/com/example/sypark9646/item11/Shape.java
@@ -1,0 +1,44 @@
+package com.example.sypark9646.item11;
+
+public class Shape {
+
+		protected int x, y;
+
+		public Shape() {
+				System.out.println("Shape 호출");
+		}
+
+		public Shape(int x, int y) {
+				this.x = x;
+				this.y = y;
+		}
+
+		public void drawCenter() {
+				System.out.println("x = " + x + ", y = " + y);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+				if (this == o) {
+						return true;
+				}
+
+				if (o == null) {
+						return false;
+				}
+
+				if (!(o instanceof Shape)) {
+						return false;
+				}
+
+				Shape shape = (Shape) o;
+				return this.x == shape.x && this.y == shape.y;
+		}
+
+		@Override
+		public int hashCode() {
+				int result = Integer.hashCode(x);
+				result = 31 * result + Integer.hashCode(y);
+				return result;
+		}
+}

--- a/sypark9646/src/test/java/com/example/sypark9646/item10/OverrideEqualTest.java
+++ b/sypark9646/src/test/java/com/example/sypark9646/item10/OverrideEqualTest.java
@@ -1,0 +1,63 @@
+package com.example.sypark9646.item10;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class OverrideEqualTest {
+
+		@Test
+		@DisplayName("인터페이스 확장 객체 equals 테스트")
+		public void testInterfaceExtensionClass() {
+				Queue<Animal> animals = new LinkedList<>();
+				animals.add(new Cat("white"));
+				animals.add(new Cat("white")); // true
+				animals.add(new Dog("white")); // false
+				animals.add(new Cat("black")); // false
+
+				Animal animal = animals.poll();
+				while (!animals.isEmpty()) {
+						Animal other = animals.poll();
+
+						System.out.println(animal + " " + other + ": " + animal.equals(other) + " " + other.equals(animal));
+				}
+		}
+
+		@Test
+		@DisplayName("컴포지션 객체 equals 테스트")
+		public void testCompositionClass() {
+				Shape shape = new Shape(1, 2);
+				Shape newShape = new Shape(1, 2);
+
+				Circle circle = new Circle(1, 2, 3);
+				Circle newCircle = new Circle(1, 2, 3);
+
+				Rectangle rectangle = new Rectangle(1, 2, 1, 2);
+				Rectangle newRectangle = new Rectangle(1, 2, 1, 2);
+
+				assertAll(
+						() -> Assertions.assertEquals(shape, circle), // false
+						() -> Assertions.assertEquals(shape, rectangle), // false
+						() -> Assertions.assertEquals(circle, rectangle), // false
+						() -> Assertions.assertEquals(shape, newShape),
+						() -> Assertions.assertEquals(circle, newCircle),
+						() -> Assertions.assertEquals(rectangle, newRectangle)
+				);
+		}
+
+		@Test
+		@DisplayName("hashSet contains 테스트")
+		public void testPutInterfaceExtensionClass() {
+				HashSet<Animal> animals = new HashSet<>();
+				animals.add(new Cat("white"));
+				animals.add(new Cat("white")); // true
+				animals.add(new Dog("white")); // false
+				animals.add(new Cat("black")); // false
+
+				Assertions.assertEquals(3, animals.size()); // false -> equals는 해시 함수와 관계 없다
+		}
+}

--- a/sypark9646/src/test/java/com/example/sypark9646/item11/OverrideHashCodeTest.java
+++ b/sypark9646/src/test/java/com/example/sypark9646/item11/OverrideHashCodeTest.java
@@ -1,0 +1,32 @@
+package com.example.sypark9646.item11;
+
+
+import java.util.HashSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class OverrideHashCodeTest {
+
+		@Test
+		@DisplayName("인터페이스 확장 객체 hashcode 테스트")
+		public void testInterfaceExtensionClass() {
+				HashSet<Animal> animals = new HashSet<>();
+				animals.add(new Cat("white"));
+				animals.add(new Cat("white")); // true
+				animals.add(new Dog("white")); // false
+				animals.add(new Cat("black")); // false
+
+				Assertions.assertEquals(3, animals.size());
+		}
+
+		@Test
+		@DisplayName("컴포지션 객체 hashcode 테스트")
+		public void testCompositionClass() {
+				HashSet<Shape> shapes = new HashSet<>();
+				shapes.add(new Shape(1, 2));
+				shapes.add(new Shape(1, 2));
+
+				Assertions.assertEquals(1, shapes.size());
+		}
+}


### PR DESCRIPTION
### Notes

* [item 10](https://sysgongbu.tistory.com/169)
* [item 11](https://sysgongbu.tistory.com/170)
* [item 12](https://sysgongbu.tistory.com/171)
* reference 
    * item10 [equals 재정의 시 getClass 대신 instanceof 를 사용하는 이유](https://stackoverflow.com/questions/596462/any-reason-to-prefer-getclass-over-instanceof-when-generating-equals/596507#596507)
    * item11 [hashtable 1](https://codingdog.tistory.com/entry/%EC%9E%90%EB%A3%8C%EA%B5%AC%EC%A1%B0-%ED%95%B4%EC%8B%9C-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%A7%81%EC%A0%91-%EA%B5%AC%ED%98%84%ED%95%B4-%EB%B4%85%EC%8B%9C%EB%8B%A4?category=1055061)
    * item11 [hashcode](https://codingdog.tistory.com/entry/%EC%99%9C-java%EC%97%90%EC%84%9C%EB%8A%94-equals-%EB%A9%94%EC%84%9C%EB%93%9C%EB%A5%BC-%EC%98%A4%EB%B2%84%EB%9D%BC%EC%9D%B4%EB%93%9C-%ED%95%98%EB%A9%B4-hashCode-%EB%8F%84-%EA%B0%99%EC%9D%B4-%ED%95%B4%EC%95%BC-%ED%95%A0%EA%B9%8C%EC%9A%94)

### Contents
* item10
```
Animal (interface)
ㄴCat
ㄴDog

Shape
Rectangle
Circle

testInterfaceExtensionClass: test equals with Interface extension objects
testCompositionClass: test equals with composition objects
testPutInterfaceExtensionClass: found that the hash function has nothing to do with equals
```

* item11
```
Same as above, but overriding hashcode() and put objects in the hashSet.
```